### PR TITLE
Draft: allow closing and opening braces to be on the same line in constructors

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -71,6 +71,12 @@ class ScopeClosingBraceSniff implements Sniff
             || ($tokens[$lineStart]['code'] === T_INLINE_HTML
             && trim($tokens[$lineStart]['content']) !== '')
         ) {
+            // Allow closing and opening brace on the same line in constructors
+            if ($tokens[$stackPtr]['code'] === T_FUNCTION 
+                && $phpcsFile->getDeclarationName($stackPtr) === '__construct'
+            ) {
+                return;
+            } 
             $error = 'Closing brace must be on a line by itself';
             $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'ContentBefore');
             if ($fix === true) {


### PR DESCRIPTION
Allow opening and closing braces to be on the same line in constructor bodies to align with the constructor property promotion introduced in PHP8.